### PR TITLE
Fix typeof checks

### DIFF
--- a/gas-template-engine/engine.js
+++ b/gas-template-engine/engine.js
@@ -97,12 +97,12 @@ function template_engine(payload, options) {
   /******************************************************************************/
   function processComplex(asProperty, asComplex, context) {
  
-      if (typeof asComplex=="undefined" || typeof asComplex == null) {
+      if (typeof asComplex ==="undefined" || asComplex === null) {
         if (asProperty) {
           processValue(asProperty, "", context); 
         }
       }
-      if (typeof asComplex == "number" || typeof asComplex == "string" || typeof asComplex == "boolean") {
+      if (typeof asComplex === "number" || typeof asComplex === "string" || typeof asComplex === "boolean") {
         if (asProperty) {
           processValue(asProperty, asComplex, context); 
         }


### PR DESCRIPTION
Don't trust `typeof asComplex === 'null'`

Why?

```JavaScript
typeof null; // --> "object"
```